### PR TITLE
Update GH pages deploy action to use new base url

### DIFF
--- a/.github/workflows/deploy-examples-site-to-pages.yml
+++ b/.github/workflows/deploy-examples-site-to-pages.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Build examples site
-        run: npm run build-site
+        run: npm run build-site -- -- --base=/big-design-patterns-sandbox/
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Upload artifact


### PR DESCRIPTION
With the change to the main `bigcommerce` org, the GH pages deploy to a folder instead of root. That breaks the asset loading so you get a blank screen when visiting https://bigcommerce.github.io/big-design-patterns-sandbox/

This PR updates the workflow to pass a `base` config param to Vite so assets load from the correct place.

Proof:
<img width="649" alt="Screenshot 2024-10-07 at 10 32 01 AM" src="https://github.com/user-attachments/assets/13b72819-e4e3-46e7-87e6-1ed7a3a38956">

<img width="889" alt="Screenshot 2024-10-07 at 10 30 50 AM" src="https://github.com/user-attachments/assets/a3b9dea6-96cf-4a1a-874a-87fe93a416d5">
