### PR TITLE
Add missing React import to CardGrid

### DIFF
--- a/packages/patterns/src/components/CardGrid/CardGrid.tsx
+++ b/packages/patterns/src/components/CardGrid/CardGrid.tsx
@@ -4,6 +4,7 @@ import { Button, Grid, Text, Flex, FlexItem } from "@bigcommerce/big-design";
 import { GridProps, GridItemProps, ButtonProps } from "@bigcommerce/big-design";
 import { ChevronRightIcon } from "@bigcommerce/big-design-icons";
 import { StyledCardGridItem } from "./styled";
+import React from "react";
 
 /**
  * Interface for button props used within the CardGridItem component.


### PR DESCRIPTION
Trying to use the CardGrid component as-is causes an error for me: 

<img width="991" alt="image" src="https://github.com/user-attachments/assets/a54a0a31-f3d1-48d8-b60a-57e69bfe61f9" />

Patching the package by adding the React import to `/node_modules/bigcommerce-design-patterns/dist/es/components/CardGrid/CardGrid.js` fix things for me. 

<img width="918" alt="image" src="https://github.com/user-attachments/assets/fc5628a3-7fe2-49ef-9ca9-6bf55c9141aa" />
