### PR TITLE
fix(docs): incorrect CopyBlocks prop

### DIFF
--- a/packages/examples-site/src/pages/CardGridPage/index.tsx
+++ b/packages/examples-site/src/pages/CardGridPage/index.tsx
@@ -22,7 +22,7 @@ const CardGridPage: FunctionComponent = () => {
     language: "jsx",
     showLineNumbers: true,
     startingLineNumber: 1,
-    wrapLines: true,
+    wrapLongLines: true,
     theme: codecolor,
     customStyle: {
       width: "100%",

--- a/packages/examples-site/src/pages/FeatureTagPage/FeatureTagPage.tsx
+++ b/packages/examples-site/src/pages/FeatureTagPage/FeatureTagPage.tsx
@@ -15,7 +15,7 @@ const PageFeatureTags: FunctionComponent = () => {
     language: "jsx",
     showLineNumbers: true,
     startingLineNumber: 1,
-    wrapLines: true,
+    wrapLongLines: true,
     theme: codecolor,
     customStyle: {
       width: "100%",

--- a/packages/examples-site/src/pages/InfoIllustrationPage/InfoIllustrationPage.tsx
+++ b/packages/examples-site/src/pages/InfoIllustrationPage/InfoIllustrationPage.tsx
@@ -16,7 +16,7 @@ const PageInfographics: FunctionComponent = () => {
     language: "jsx",
     showLineNumbers: true,
     startingLineNumber: 1,
-    wrapLines: true,
+    wrapLongLines: true,
     theme: codecolor,
     customStyle: {
       width: "100%",


### PR DESCRIPTION
# What/Why

Responsiveness on some of the pages on the [patterns sandbox page](https://bigcommerce.github.io/big-design-patterns-sandbox) are broken due to the long text overflowing out of the container. 

[**Before**]

![Screenshot 2025-03-12 at 5 05 34 PM](https://github.com/user-attachments/assets/12533db8-9f96-4a17-9c0c-801bd538ec3c)

[**After**]

![Screenshot 2025-03-12 at 5 10 18 PM](https://github.com/user-attachments/assets/6ab66532-25c9-4edb-be5d-42b1b4776670)
