### PR TITLE
Revert examples site package name

### DIFF
--- a/packages/examples-site/package.json
+++ b/packages/examples-site/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bigcommerce-examples-site",
+  "name": "examples-site",
   "private": true,
   "version": "0.5.1",
   "scripts": {


### PR DESCRIPTION
In the changesets PR the package name of the examples site was updated while it was turned private. The name change broke the example site build commands.

This changes the name back to the previous version to resolve that issue.