### PR TITLE
Add nav sidebar

### DIFF
--- a/.changeset/silver-bikes-mix.md
+++ b/.changeset/silver-bikes-mix.md
@@ -1,0 +1,6 @@
+---
+"examples-site": minor
+"bigcommerce-design-patterns": minor
+---
+
+Add sidebar

--- a/packages/examples-site/package.json
+++ b/packages/examples-site/package.json
@@ -17,6 +17,7 @@
     "react": "^18.0.0",
     "react-code-blocks": "^0.1.6",
     "react-dom": "^18.0.0",
+    "react-icons": "^5.5.0",
     "react-is": "^18.3.1",
     "react-router": "^6.15.0",
     "react-router-dom": "^6.15.0",

--- a/packages/examples-site/src/App.tsx
+++ b/packages/examples-site/src/App.tsx
@@ -48,6 +48,12 @@ const MainContent = styled.main`
 const ContentArea = styled.div`
   height: 100%;
   overflow: auto;
+
+  &:last-child::after {
+    height: 3rem;
+    content: " ";
+    display: block;
+  }
 `;
 
 const HeaderContainer = styled(Box)`

--- a/packages/examples-site/src/App.tsx
+++ b/packages/examples-site/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from "react";
-import { BrowserRouter as Router, useRoutes } from "react-router-dom";
+import { BrowserRouter as Router, useRoutes, useNavigate } from "react-router-dom";
+import styled from "styled-components";
 import PageHome from "./pages/Home/Home";
 import PageList from "./pages/ListPage/ListPage";
 import PageForm from "./pages/FormPage/FormPage";
@@ -7,7 +8,7 @@ import PageInfoIllustration from "./pages/InfoIllustrationPage/InfoIllustrationP
 import PageFeatureTags from "./pages/FeatureTagPage/FeatureTagPage";
 import PageFeaturedContent from "./pages/FeaturedContentPage/FeaturedContentPage";
 import SelectPage from "./pages/SelectPage/SelectPage";
-import { AlertsManager, createAlertsManager } from "@bigcommerce/big-design";
+import { AlertsManager, createAlertsManager, Button, Dropdown, Box, Flex, FlexItem, Link, Text, DropdownItemGroup } from "@bigcommerce/big-design";
 import PageCRUDList from "./pages/CRUDListPage/CRUDListPage";
 import PageCRUDAddEdit from "./pages/CRUDAddEditPage/CRUDAddEditPage";
 import PageAnchorNav from "./pages/AnchorNavPage/AnchorNavPage";
@@ -19,7 +20,140 @@ import PageFiltersDropdowns from "./pages/Filters/FiltersDropdownsPage/FiltersDr
 import PageFiltersAdvanced from "./pages/Filters/FiltersAdvPage/FiltersAdvancedPage";
 import PageFiltersAdvancedAdditive from "./pages/Filters/FiltersAdvancedAdditivePage/FiltersAdvancedAdditivePage";
 import DashboardLayout from "./pages/DashboardLayoutPage";
+import Sidebar from "../../patterns/src/components/sidebar/sidebar";
+import { SidebarProvider } from "../../patterns/src/components/sidebar/sidebar-context";
+import { ReactRouterProviderAdapter } from "./adapters/react-router-adapter";
+import { menuItems } from "./config/menu-items";
+import { BiLogoGithub } from "react-icons/bi";
+
 export const alertsManager = createAlertsManager();
+
+const LayoutContainer = styled.div`
+  display: grid;
+  height: 100vh;
+  width: 100%;
+`;
+
+const InnerContainer = styled.div`
+  min-height: 100vh;
+  overflow: hidden;
+`;
+
+const MainContent = styled.main`
+  display: grid;
+  height: 100%;
+  grid-template-columns: max-content 1fr;
+`;
+
+const ContentArea = styled.div`
+  height: 100%;
+  overflow: auto;
+`;
+
+const HeaderContainer = styled(Box)`
+  width: 100%;
+  grid-column: 1 / -1;
+  background-color: white;
+`;
+
+const NavTitleContainer = styled(FlexItem)`
+  width: 198px;
+  display: block;
+  text-align: center;
+`;
+
+const NavTitleText = styled.span`
+  font-size: 0.875rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+`;
+
+const LogoContainer = styled(FlexItem)`
+  padding: 0.6rem 1rem;
+  margin-top: 0.4rem;
+  color: #000;
+  cursor: pointer;
+`;
+
+const GitHubLink = styled(Link)`
+  color: #000;
+
+  &:hover {
+    color: #DBE3FE !important;
+  }
+`;
+
+const DesktopMenu = () => (
+  <Box marginLeft="auto">
+    <Flex alignItems="center" flexGap="0.5rem">
+      <FlexItem>
+        <GitHubLink href="https://github.com/bigcommerce/big-design-patterns-sandbox" target="_blank">
+          <BiLogoGithub size={"24px"}/>
+        </GitHubLink>
+      </FlexItem>
+    </Flex>
+  </Box>
+);
+
+function Header() {
+  const navigate = useNavigate();
+  
+  return (
+    <Box
+      borderBottom="box"
+      paddingRight={{ mobile: "medium", tablet: "xLarge" }}
+    >
+      <Flex
+        flexDirection="row"
+        alignItems="center"
+        justifyContent="space-between"
+      >
+        <Flex flexDirection="row" alignItems="center">
+          <LogoContainer onClick={(e) => {
+            e.preventDefault();
+            navigate('/');
+          }}>
+            <img src="/assets/images/icons/bigc-inverted-black.svg" alt="BigDesign Pattern Sandbox"
+              style={{
+                width: "24px",
+                height: "24px",
+                fill: "currentColor",
+              }}
+            />
+          </LogoContainer>
+          <NavTitleContainer
+            borderLeft="box"
+            borderRight="box"
+            paddingVertical="medium"
+            paddingHorizontal="xSmall"
+          >
+            <NavTitleText>
+              BigDesign Patterns
+            </NavTitleText> 
+          </NavTitleContainer>
+        </Flex>
+        <DesktopMenu />
+      </Flex>
+    </Box>
+  );
+}
+
+const AppLayout = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <LayoutContainer>
+      <InnerContainer>
+        <HeaderContainer>
+          <Header/>
+        </HeaderContainer>
+        <MainContent>
+          <Sidebar menuItems={menuItems} />
+          <ContentArea>{children}</ContentArea>
+        </MainContent>
+      </InnerContainer>
+    </LayoutContainer>
+  );
+};
 
 const RouteFC = () => {
   let routes = useRoutes([
@@ -46,6 +180,7 @@ const RouteFC = () => {
       element: <PageFiltersAdvancedAdditive />,
     },
   ]);
+  
   return routes;
 };
 
@@ -54,7 +189,13 @@ const App: FunctionComponent = () => {
     <>
       <AlertsManager manager={alertsManager} />
       <Router basename={import.meta.env.BASE_URL}>
-        <RouteFC />
+        <ReactRouterProviderAdapter>
+          <SidebarProvider>
+            <AppLayout>
+              <RouteFC />
+            </AppLayout>
+          </SidebarProvider>
+        </ReactRouterProviderAdapter>
       </Router>
     </>
   );

--- a/packages/examples-site/src/App.tsx
+++ b/packages/examples-site/src/App.tsx
@@ -46,14 +46,8 @@ const MainContent = styled.main`
 `;
 
 const ContentArea = styled.div`
-  height: 100%;
+  height: calc(100vh - 3.5rem);
   overflow: auto;
-
-  &:last-child::after {
-    height: 3rem;
-    content: " ";
-    display: block;
-  }
 `;
 
 const HeaderContainer = styled(Box)`

--- a/packages/examples-site/src/adapters/next-router-adapter.tsx
+++ b/packages/examples-site/src/adapters/next-router-adapter.tsx
@@ -1,0 +1,36 @@
+/*
+// This file is provided as a reference for implementing a Next.js router adapter
+// If needed in the future, uncomment and adapt to your specific Next.js version
+
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import { ReactNode } from 'react';
+import { RouterContextType } from "../../../patterns/src/contexts/router-context";
+import { RouterProvider } from "../../../patterns/src/contexts/router-context";
+
+// Next.js Router Adapter
+export const NextRouterAdapter = (): RouterContextType => {
+  const router = useRouter();
+
+  return {
+    pathname: router.pathname,
+    navigate: (path: string) => router.push(path),
+    Link: ({ href, className, children }: { href: string; className?: string; children: ReactNode }) => (
+      <Link href={href}>
+        <a className={className}>{children}</a>
+      </Link>
+    ),
+  };
+};
+
+// Usage Example:
+export const NextRouterProviderAdapter = ({ children }: { children: ReactNode }) => {
+  const routerAdapter = NextRouterAdapter();
+  
+  return (
+    <RouterProvider value={routerAdapter}>
+      {children}
+    </RouterProvider>
+  );
+};
+*/

--- a/packages/examples-site/src/adapters/react-router-adapter.tsx
+++ b/packages/examples-site/src/adapters/react-router-adapter.tsx
@@ -1,0 +1,33 @@
+import { useLocation, useNavigate, Link as ReactRouterLink } from "react-router-dom";
+import { ReactNode } from "react";
+import { RouterContextType } from "../../../patterns/src/components/sidebar/hooks/router-context";
+
+// React Router adapter for the RouterContext
+export const ReactRouterAdapter = (): RouterContextType => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  return {
+    pathname: location.pathname,
+    navigate: (path: string) => navigate(path),
+    Link: ({ href, className, children }: { href: string; className?: string; children: ReactNode }) => (
+      <ReactRouterLink to={href} className={className}>
+        {children}
+      </ReactRouterLink>
+    ),
+  };
+};
+
+// Component that provides the router context using React Router
+export const ReactRouterProviderAdapter = ({ children }: { children: ReactNode }) => {
+  const routerAdapter = ReactRouterAdapter();
+  
+  return (
+    <RouterProvider value={routerAdapter}>
+      {children}
+    </RouterProvider>
+  );
+};
+
+// Need to import RouterProvider here since it's used in the component
+import { RouterProvider } from "../../../patterns/src/components/sidebar/hooks/router-context";

--- a/packages/examples-site/src/config/menu-items.ts
+++ b/packages/examples-site/src/config/menu-items.ts
@@ -1,0 +1,126 @@
+import type { MenuItem } from "bigcommerce-design-patterns";
+import { BiBookContent, BiGrid, BiGridAlt, BiExtension, BiFoodMenu,BiJoystickButton } from "react-icons/bi";
+
+export const menuItems: MenuItem[] = [
+  {
+    hash: "sidebar-home",
+    label: "Home",
+    href: "/",
+    icon: BiBookContent,
+  },
+  {
+    hash: "sidebar-sample-flows",
+    label: "Sample Flows",
+    icon: BiGrid,
+    items: [
+      {
+        hash: "sidebar-page-crud-list",
+        label: "CRUD flow (Page)",
+        href: "/page-crud-list",
+      },
+      {
+        hash: "sidebar-page-crud-add",
+        label: "CRUD Add",
+        href: "/page-crud-add",
+      },
+    ]
+  },
+  {
+    hash: "sidebar-single-page-patterns",
+    label: "Single Page Patterns",
+    icon: BiGridAlt,
+    items: [
+      {
+        hash: "sidebar-page-list",
+        label: "List Page",
+        href: "/page-list",
+      },
+      {
+        hash: "sidebar-page-featured-content",
+        label: "Featured Content Page",
+        href: "/page-featured-content",
+      },
+      {
+        hash: "sidebar-page-form",
+        label: "Form Page",
+        href: "/page-form",
+      },
+      {
+        hash: "sidebar-page-anchor-nav",
+        label: "Anchor Navigation Page",
+        href: "/page-anchor-nav",
+      },
+    ]
+  },
+  {
+    hash: "sidebar-data-filtering",
+    label: "Data filtering",
+    icon: BiFoodMenu,
+    items: [
+      {
+        hash: "sidebar-filters-search",
+        label: "Simple search",
+        href: "/filters-search",
+      },
+      {
+        hash: "sidebar-filters-dropdowns",
+        label: "Dropdown filtering",
+        href: "/filters-dropdowns",
+      },
+      {
+        hash: "sidebar-filters-advanced",
+        label: "Advanced filtering",
+        href: "/filters-advanced",
+      },
+      {
+        hash: "sidebar-filters-advanced-additive",
+        label: "Advanced additive filtering with views",
+        href: "/filters-advanced-additive",
+      },
+    ]
+  },
+  {
+    hash: "sidebar-pattern-components",
+    label: "Pattern Components",
+    icon: BiExtension,
+    items: [
+      {
+        hash: "sidebar-feature-tag",
+        label: "Feature Tags",
+        href: "/feature-tag",
+      },
+      {
+        hash: "sidebar-card-grid",
+        label: "Card Grid",
+        href: "/card-grid",
+      },
+      {
+        hash: "sidebar-info-illustration",
+        label: "Info Illustrations",
+        href: "/info-illustration",
+      },
+      {
+        hash: "sidebar-dashboard-layout",
+        label: "Dashboard Layout",
+        href: "/dashboard-layout",
+      },
+    ]
+  },
+  {
+    hash: "sidebar-install-screen",
+    label: "Install Screens",
+    icon: BiJoystickButton,
+    items: [
+      {
+        hash: "sidebar-install-screen-app",
+        label: "Install Apps",
+        href: "/install-screen-app",
+      },
+      {
+        hash: "sidebar-install-screen-channel",
+        label: "Install Channels",
+        href: "/install-screen-channel",
+      },
+    ]
+  },
+];

--- a/packages/patterns/src/components/sidebar/hooks/router-context.tsx
+++ b/packages/patterns/src/components/sidebar/hooks/router-context.tsx
@@ -1,0 +1,30 @@
+import React, { createContext, useContext, ReactNode } from 'react';
+
+export interface RouterContextType {
+  pathname: string;
+  navigate: (path: string) => void;
+  Link: React.ComponentType<{ href: string; className?: string; children: ReactNode }>;
+}
+
+const RouterContext = createContext<RouterContextType | null>(null);
+
+export const useRouter = (): RouterContextType => {
+  const context = useContext(RouterContext);
+  if (!context) {
+    throw new Error('useRouter must be used within a RouterProvider');
+  }
+  return context;
+};
+
+export interface RouterProviderProps {
+  children: ReactNode;
+  value: RouterContextType;
+}
+
+export const RouterProvider: React.FC<RouterProviderProps> = ({ children, value }) => {
+  return (
+    <RouterContext.Provider value={value}>
+      {children}
+    </RouterContext.Provider>
+  );
+};

--- a/packages/patterns/src/components/sidebar/hooks/use-toggle.ts
+++ b/packages/patterns/src/components/sidebar/hooks/use-toggle.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useMemo, useReducer, type Dispatch, type ReactNode } from "react";
+
+export type BooleanHandlers = {
+  toggle: Dispatch<boolean>;
+  on: () => void;
+  off: () => void;
+};
+
+const toggler = (currentValue: boolean, newValue: boolean) => {
+  return typeof newValue === "boolean" ? newValue : !currentValue;
+};
+
+export const useToggle = (initialValue: boolean = false) => {
+  return useReducer(toggler, initialValue);
+};
+
+export const useBoolean = (
+  initialValue: boolean = false,
+): [boolean, BooleanHandlers] => {
+  const [value, toggle] = useToggle(initialValue);
+
+  const handlers = useMemo(
+    () => ({
+      toggle,
+      on: () => toggle(true),
+      off: () => toggle(false),
+    }),
+    [toggle],
+  );
+
+  return [value, handlers];
+};
+
+export const BooleanProvider = ({
+  children,
+}: {
+  children: (value: boolean, handlers: BooleanHandlers) => ReactNode;
+}) => {
+  const [value, handlers] = useBoolean();
+
+  return children(value, handlers);
+};

--- a/packages/patterns/src/components/sidebar/hooks/use-window-size.ts
+++ b/packages/patterns/src/components/sidebar/hooks/use-window-size.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+
+const BREAKPOINTS = {
+  MOBILE: 720,
+  TABLET: 1024,
+} as const;
+
+type WindowSize = {
+  width: number | null;
+  height: number | null;
+};
+
+type ScreenSize = {
+  isMobile: boolean;
+  isTablet: boolean;
+  isDesktop: boolean;
+};
+
+export const useWindowSize = () => {
+  const [size, setSize] = useState<WindowSize>({
+    width: null,
+    height: null,
+  });
+
+  const [screenSize, setScreenSize] = useState<ScreenSize>({
+    isMobile: false,
+    isTablet: false,
+    isDesktop: false,
+  });
+
+  useEffect(() => {
+    const handleWindowResize = () => {
+      const width = window.innerWidth;
+
+      setSize({
+        width,
+        height: window.innerHeight,
+      });
+
+      setScreenSize({
+        isMobile: width < BREAKPOINTS.MOBILE,
+        isTablet: width >= BREAKPOINTS.MOBILE && width < BREAKPOINTS.TABLET,
+        isDesktop: width >= BREAKPOINTS.TABLET,
+      });
+    };
+
+    handleWindowResize();
+
+    window.addEventListener("resize", handleWindowResize);
+
+    return () => {
+      window.removeEventListener("resize", handleWindowResize);
+    };
+  }, []);
+
+  return { size, ...screenSize };
+};

--- a/packages/patterns/src/components/sidebar/index.ts
+++ b/packages/patterns/src/components/sidebar/index.ts
@@ -1,0 +1,2 @@
+export * from "./sidebar";
+export type { MenuItem } from "./menu-items.types";

--- a/packages/patterns/src/components/sidebar/menu-items.types.ts
+++ b/packages/patterns/src/components/sidebar/menu-items.types.ts
@@ -1,0 +1,16 @@
+export type MenuItem = Readonly<{
+  hash: string;
+  label: string;
+  isActive?: boolean;
+  icon?: React.ElementType;
+  external?: boolean;
+  href?: string;
+  items?: SubMenuItem[];
+}>;
+
+/**
+ * We're only supporting single-level nested menu so we need the children to have hrefs.
+ */
+type SubMenuItem = Omit<MenuItem, "href"> & {
+  href: string;
+};

--- a/packages/patterns/src/components/sidebar/sidebar-constants.ts
+++ b/packages/patterns/src/components/sidebar/sidebar-constants.ts
@@ -1,0 +1,2 @@
+export const COLLAPSED_WIDTH = 40;
+export const EXPANDED_WIDTH = 237;

--- a/packages/patterns/src/components/sidebar/sidebar-context.tsx
+++ b/packages/patterns/src/components/sidebar/sidebar-context.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { createContext, ReactNode, useEffect } from "react";
+
+import { useBoolean } from "./hooks/use-toggle";
+import { useWindowSize } from "./hooks/use-window-size";
+
+type SidebarContextType = {
+  isCollapsed: boolean;
+  toggleIsCollapsed: () => void;
+  openSidebar: () => void;
+  closeSidebar: () => void;
+};
+
+export const SidebarContext = createContext<SidebarContextType>({
+  isCollapsed: false,
+  toggleIsCollapsed: () => {},
+  openSidebar: () => {},
+  closeSidebar: () => {},
+});
+
+type SidebarProviderProps = {
+  children: ReactNode | ReactNode[];
+};
+
+export const SidebarProvider = ({ children }: SidebarProviderProps) => {
+  const { isTablet, isMobile } = useWindowSize();
+  const [isCollapsed, { toggle, on, off }] = useBoolean(false);
+
+  // This is to make sure that the sidebar is collapsed when going from desktop to mobile
+  useEffect(() => {
+    if (!isCollapsed && (isTablet || isMobile)) {
+      toggle(true);
+    }
+  }, [isTablet, isMobile]);
+
+  return (
+    <SidebarContext.Provider
+      value={{
+        isCollapsed,
+        toggleIsCollapsed: () => toggle(!isCollapsed),
+        openSidebar: off, // Off because we set isCollapsed to false
+        closeSidebar: on, // On because we set isCollapsed to true
+      }}
+    >
+      {children}
+    </SidebarContext.Provider>
+  );
+};

--- a/packages/patterns/src/components/sidebar/sidebar-menu.tsx
+++ b/packages/patterns/src/components/sidebar/sidebar-menu.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useContext } from "react";
+import styled from "styled-components";
+
+import { SidebarContext } from "./sidebar-context";
+import { SidebarNavLink } from "./sidebar-nav-link";
+import { SidebarSubNav } from "./sidebar-subnav";
+import { useRouter } from "./hooks/router-context";
+import { MenuItem } from "./menu-items.types";
+
+import {
+  COLLAPSED_WIDTH,
+  EXPANDED_WIDTH,
+} from "./sidebar-constants";
+
+const StyledNav = styled.nav<{ width: string }>`
+  height: 100%;
+  width: ${props => props.width};
+  transform-origin: left;
+  transition: width 300ms ease-in-out;
+`;
+
+const StyledMenuContainer = styled.div`
+  width: 100%;
+`;
+
+export const SidebarMenu = ({ menuItems }: { menuItems: MenuItem[] }) => {
+  const { isCollapsed } = useContext(SidebarContext);
+  const { pathname } = useRouter();
+  
+  const navWidth = !isCollapsed ? `${EXPANDED_WIDTH}px` : `${COLLAPSED_WIDTH}px`;
+
+  return (
+    <StyledNav width={navWidth}>
+      <StyledMenuContainer>
+        {menuItems.map((item) => {
+          if (item?.items && item.items.length > 0) {
+            return <SidebarSubNav key={item.hash} {...item} />;
+          }
+
+          return (
+            <SidebarNavLink
+              key={item.hash}
+              isActive={pathname === item.href}
+              isCollapsed={isCollapsed}
+              {...item}
+            />
+          );
+        })}
+      </StyledMenuContainer>
+    </StyledNav>
+  );
+};

--- a/packages/patterns/src/components/sidebar/sidebar-nav-link.tsx
+++ b/packages/patterns/src/components/sidebar/sidebar-nav-link.tsx
@@ -1,0 +1,88 @@
+import { memo } from "react";
+import styled from "styled-components";
+
+import type { MenuItem } from "./menu-items.types";
+import { useRouter } from "./hooks/router-context";
+
+type SidebarNavLinkProps = {
+  className?: string;
+  isCollapsed?: boolean;
+} & Omit<MenuItem, "items">;
+
+const StyledLink = styled.a<{ isActive?: boolean }>`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+  overflow: hidden;
+  border-radius: 0.25rem;
+  padding: 0.5rem;
+  color: #313440;
+  text-decoration: none;
+
+  ${props => !props.isActive && `
+  &:hover {
+    background-color: #F0F3FF;
+  }`}
+
+  ${props => props.isActive && `
+    background-color: #DBE3FE;
+    font-weight: 600;
+    color:rgb(0, 36, 166);
+  `}
+`;
+
+const LinkText = styled.span<{ isCollapsed?: boolean }>`
+  display: ${props => props.isCollapsed ? 'none' : 'inline-block'};
+  opacity: ${props => props.isCollapsed ? 0 : 1};
+  font-size: 1rem;
+  flex-shrink: 1;
+  
+  @media (min-width: 768px) {
+    transition: opacity, display;
+    transition-behavior: allow-discrete;
+  }
+`;
+
+const IconPlaceholder = styled.div`
+  width: 24px;
+  height: 24px;
+  
+  flex-shrink: 0;
+`;
+
+const IconWrapper = styled.div`
+  display: flex;
+  flex-shrink: 0;
+`;
+
+export const SidebarNavLink = memo(
+  ({ className, isCollapsed, ...props }: SidebarNavLinkProps) => {
+    const { Link } = useRouter();
+    const Icon = props.icon;
+    
+    if (props.href) {
+      return (
+        <StyledLink
+          as={Link}
+          href={props.href}
+          isActive={props.isActive}
+          className={className}
+        >
+          {Icon ? (
+            <IconWrapper>
+              <Icon />
+            </IconWrapper>
+          ) : <IconPlaceholder />}
+          
+          <LinkText isCollapsed={isCollapsed}>
+            {props.label}
+          </LinkText>
+        </StyledLink>
+      );
+    }
+    return <div>{props.label}</div>;
+  },
+);
+
+SidebarNavLink.displayName = "SidebarNavLink";

--- a/packages/patterns/src/components/sidebar/sidebar-subnav.tsx
+++ b/packages/patterns/src/components/sidebar/sidebar-subnav.tsx
@@ -1,0 +1,211 @@
+import type { MenuItem } from "./menu-items.types";
+import { ExpandMoreIcon } from "@bigcommerce/big-design-icons";
+import React, { ReactNode, useContext, useEffect, useMemo } from "react";
+import styled from "styled-components";
+
+import { SidebarContext } from "./sidebar-context";
+import { SidebarNavLink } from "./sidebar-nav-link";
+import { useRouter } from "./hooks/router-context";
+import { useBoolean } from "./hooks/use-toggle";
+
+const NavContainer = styled.div`
+  overflow: hidden;
+`;
+
+const NavHeader = styled.div<{ hasActiveChild: boolean }>`
+  display: flex;
+  cursor: pointer;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+  white-space: nowrap;
+  border-radius: 0.25rem;
+  padding: 0.5rem;
+  transition: background-color 0.3s;
+
+  &:hover {
+    background-color: rgb(240, 243, 255);
+    color: rgb(40, 82, 235);
+  }
+
+  ${props => props.hasActiveChild && `
+    background-color: rgb(246, 247, 252);
+  `}
+`;
+
+const NavButton = styled.button`
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+`;
+
+const NavLabel = styled.span<{ isCollapsed: boolean }>`
+  font-size: 1rem;
+  display: ${props => props.isCollapsed ? 'none' : 'inline-block'};
+  opacity: ${props => props.isCollapsed ? 0 : 1};
+  
+  @media (min-width: 768px) {
+    transition: opacity, display;
+    transition-behavior: allow-discrete;
+  }
+`;
+
+const ExpandButton = styled.button<{ isCollapsed: boolean }>`
+  display: ${props => props.isCollapsed ? 'none' : 'block'};
+  border-radius: 0.25rem;
+  transition: background-color 0.3s;
+  border: none;
+  background: none;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #F6F7FC;
+  }
+`;
+
+const ExpandIcon = styled(ExpandMoreIcon)<{ isOpen: boolean }>`
+  transition: transform 0.3s;
+  transform: ${props => props.isOpen ? 'rotate(180deg)' : 'rotate(0)'};
+`;
+
+const SubnavContainer = styled.div<{ isOpen: boolean; isCollapsed: boolean }>`
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.3s;
+  
+  & > div {
+    overflow: hidden;
+  }
+  
+  ${props => (!props.isCollapsed && props.isOpen) && `
+    grid-template-rows: 1fr;
+  `}
+`;
+
+const SubnavItem = styled.div`
+  position: relative;
+  &:hover {
+    border-color: #3b82f6;
+    background-color: #ECEEF5;
+  }
+`;
+
+const StyledNavLink = styled(SidebarNavLink)<{ isActive: boolean }>`
+  overflow: hidden;
+  transition: background-color 0.3s;
+  
+  &::after {
+    content: '';
+    position: absolute;
+    left: 1rem;
+    top: 0;
+    height: 100%;
+    width: 1px;
+    background-color: #D9DCE9;
+    ${props => props.isActive && `background-color: rgb(60, 100, 244);`}
+  }
+  
+  &:hover::after {
+    background-color: ${props => props.isActive ? 'rgb(60, 100, 244)' : 'rgb(158, 179, 252)'};
+  }
+  
+  ${props => props.isActive && `
+    background-color: rgb(219, 227, 254);
+    color: rgb(11, 56, 217);
+
+  `}
+`;
+
+interface SidebarSubNavProps {
+  items?: MenuItem[] | undefined;
+  icon?: React.ElementType;
+  label: string;
+  hash: string;
+}
+
+export const SidebarSubNav = (props: SidebarSubNavProps) => {
+  const { isCollapsed } = useContext(SidebarContext);
+  const { pathname, navigate } = useRouter();
+
+  const hasActiveChild = useMemo(
+    () => props.items?.some((item) => item.href && pathname.startsWith(item.href)) ?? false,
+    [pathname, props.items],
+  );
+
+  const [
+    isSubnavOpened,
+    { toggle: toggleSubnavState, on: openSubnav, off: closeSubnav },
+  ] = useBoolean(hasActiveChild);
+
+  useEffect(() => {
+    if (!hasActiveChild) {
+      closeSubnav();
+    }
+  }, [hasActiveChild, closeSubnav]);
+
+  if (!props.items || props.items.length === 0) return null;
+
+  const Icon = props.icon;
+
+  return (
+    <NavContainer>
+      <NavHeader 
+        hasActiveChild={hasActiveChild}
+        onClick={() => {
+          if (props.items?.[0]?.href) {
+            navigate(props.items[0]!.href);
+          }
+          openSubnav();
+        }}
+      >
+        <NavButton>
+          {Icon && (
+            <Icon
+              className="inline-block"
+              isActive={hasActiveChild || false}
+            />
+          )}
+
+          <NavLabel isCollapsed={isCollapsed}>
+            {props.label}
+          </NavLabel>
+        </NavButton>
+        <ExpandButton
+          isCollapsed={isCollapsed}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            toggleSubnavState(!isSubnavOpened);
+          }}
+        >
+          <ExpandIcon 
+            color="secondary60"
+            isOpen={isSubnavOpened}
+          />
+        </ExpandButton>
+      </NavHeader>
+      <SubnavContainer isOpen={isSubnavOpened} isCollapsed={isCollapsed}>
+        <div>
+          {props.items?.map(({ icon, ...item }) => {
+            const isActive = item.href ? pathname.startsWith(item.href) : false;
+
+            return (
+              <SubnavItem key={item.hash}>
+                <StyledNavLink
+                  isActive={isActive}
+                  isCollapsed={isCollapsed}
+                  {...item}
+                />
+              </SubnavItem>
+            );
+          })}
+        </div>
+      </SubnavContainer>
+    </NavContainer>
+  );
+};

--- a/packages/patterns/src/components/sidebar/sidebar-toggle.tsx
+++ b/packages/patterns/src/components/sidebar/sidebar-toggle.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { ChevronLeftIcon } from "@bigcommerce/big-design-icons";
+import { useContext } from "react";
+import styled from "styled-components";
+
+import { SidebarContext } from "./sidebar-context";
+
+const ToggleButton = styled.button`
+  position: absolute;
+  right: -0.875rem;
+  bottom: 25%;
+  display: none;
+  border-radius: 9999px;
+  border: 1px solid #D9DCE9;
+  background-color: white;
+  padding: 0;
+  
+  @media (min-width: 768px) {
+    display: inline-flex;
+  }
+
+  &:hover {
+    background-color: #F4F5FA;
+  }
+`;
+
+const StyledIcon = styled(ChevronLeftIcon)<{ isCollapsed: boolean }>`
+  width: 24px;
+  height: 24px;
+  transition: transform 150ms;
+  transition-delay: 150ms;
+  cursor: pointer;
+  transform: ${props => props.isCollapsed ? 'rotate(180deg)' : 'rotate(0)'};
+`;
+
+export const SidebarToggle = () => {
+  const { isCollapsed, toggleIsCollapsed } = useContext(SidebarContext);
+
+  return (
+    <ToggleButton onClick={toggleIsCollapsed}>
+      <StyledIcon color="secondary60" isCollapsed={isCollapsed} />
+    </ToggleButton>
+  );
+};

--- a/packages/patterns/src/components/sidebar/sidebar.tsx
+++ b/packages/patterns/src/components/sidebar/sidebar.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useContext } from "react";
+import styled from "styled-components";
+
+import { SidebarContext } from "./sidebar-context";
+import { SidebarMenu } from "./sidebar-menu";
+import { SidebarToggle } from "./sidebar-toggle";
+import { MenuItem } from "./menu-items.types";
+
+const DesktopAside = styled.aside`
+  position: relative;
+  z-index: 10;
+  display: none;
+  border-right: 1px solid #D9DCE9;
+  padding: 0.5rem;
+  background-color: white;
+  
+  @media (min-width: 720px) {
+    display: block;
+  }
+`;
+
+const MobileAside = styled.aside<{ isCollapsed: boolean }>`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  top: 57px;
+  z-index: 50;
+  border-right: 1px solid #D9DCE9;
+  background-color: white;
+  transition: transform 0.3s;
+  transform: ${props => props.isCollapsed ? 'translateX(-100%)' : 'translateX(0)'};
+  
+  @media (min-width: 720px) {
+    display: none;
+  }
+`;
+
+const Overlay = styled.div`
+  position: absolute;
+  inset: 0;
+  top: 57px;
+  z-index: 40;
+  display: block;
+  background-color: rgba(0, 0, 0, 0.4);
+  
+  @media (min-width: 768px) {
+    display: none;
+  }
+`;
+
+function SidebarDesktop({ menuItems }: { menuItems: MenuItem[] }) {
+  return (
+    <DesktopAside>
+      <SidebarMenu menuItems={menuItems} />
+      <SidebarToggle />
+    </DesktopAside>
+  );
+}
+
+function SidebarMobile({ menuItems }: { menuItems: MenuItem[] }) {
+  const { isCollapsed, closeSidebar } = useContext(SidebarContext);
+
+  return (
+    <>
+      <MobileAside isCollapsed={isCollapsed}>
+        <SidebarMenu menuItems={menuItems} />
+      </MobileAside>
+      {!isCollapsed && <Overlay onClick={closeSidebar} />}
+    </>
+  );
+}
+
+export default function Sidebar({ menuItems = [] }: { menuItems?: MenuItem[] }) {
+  return (
+    <>
+      <SidebarDesktop menuItems={menuItems} />
+      <SidebarMobile menuItems={menuItems} />
+    </>
+  );
+}

--- a/packages/patterns/src/index.ts
+++ b/packages/patterns/src/index.ts
@@ -11,3 +11,4 @@ export * from "./components/InfoIllustration/InfoIllustration";
 export * from "./components/InstallScreen";
 export * from "./components/scroller/Scroller";
 export * from "./components/dashboardLayout";
+export * from "./components/sidebar";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       react-dom:
         specifier: ^18.0.0
         version: 18.3.1(react@18.3.1)
+      react-icons:
+        specifier: ^5.5.0
+        version: 5.5.0(react@18.3.1)
       react-is:
         specifier: ^18.3.1
         version: 18.3.1
@@ -3511,6 +3514,11 @@ packages:
 
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
+
+  react-icons@5.5.0:
+    resolution: {integrity: sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==}
+    peerDependencies:
+      react: '*'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -8266,6 +8274,10 @@ snapshots:
       scheduler: 0.23.2
 
   react-fast-compare@3.2.2: {}
+
+  react-icons@5.5.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   react-is@16.13.1: {}
 


### PR DESCRIPTION
This adds a nav bar to the , mostly pulled from the new dev portal, so we can preview patterns within an "admin" viewport.

Output of Georgia's comment on the dashboard layout PR here: https://github.com/bigcommerce/big-design-patterns-sandbox/pull/23#issuecomment-2743224645

<img width="1624" alt="Screenshot 2025-03-26 at 11 05 17 AM" src="https://github.com/user-attachments/assets/b92686de-1474-4d92-89e2-c31c2f11d784" />
