### PR TITLE
Add publishConfig to package.json for public access

### DIFF
--- a/.changeset/some-moles-work.md
+++ b/.changeset/some-moles-work.md
@@ -1,0 +1,5 @@
+---
+"bigcommerce-design-patterns": patch
+---
+
+Add public publish config property to package.json

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -11,6 +11,9 @@
       "require": "./dist/cjs/index.js"
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Adding the publishConfig back with only the `access: public` should fix the error we're receiving on publish

```
🦋  error an error occurred while publishing bigcommerce-design-patterns: EUNSCOPED Can't restrict access to unscoped packages. 
🦋  error npm notice Publishing to https://registry.npmjs.org/ with tag latest and restricted access
🦋  error npm error code EUNSCOPED
🦋  error npm error Can't restrict access to unscoped packages.
```