### PR TITLE
Update Patterns exports and bump BD dependencies

### DIFF
--- a/.changeset/shiny-games-dig.md
+++ b/.changeset/shiny-games-dig.md
@@ -1,0 +1,5 @@
+---
+"bigcommerce-design-patterns": patch
+---
+
+Fix package.json so patterns work in dev environment

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -6,9 +6,9 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "development": "./src/index.ts",
       "import": "./dist/es/index.js",
-      "require": "./dist/cjs/index.js"
+      "require": "./dist/cjs/index.js",
+      "default": "./dist/es/index.js"
     }
   },
   "publishConfig": {
@@ -21,12 +21,13 @@
     "build": "pnpm run build:cjs && pnpm run build:es && pnpm run build:dt",
     "build:cjs": "NODE_ENV=production BABEL_ENV=cjs babel --extensions \".ts,.tsx\" ./src --out-dir ./dist/cjs",
     "build:es": "NODE_ENV=production BABEL_ENV=es babel --extensions \".ts,.tsx\" ./src --out-dir ./dist/es",
-    "build:dt": "tsc -p tsconfig.declarations.json --emitDeclarationOnly"
+    "build:dt": "tsc -p tsconfig.declarations.json --emitDeclarationOnly",
+    "build:watch": "babel --watch ./src --out-dir ./dist/es --extensions \".ts,.tsx\" --env-name es"
   },
   "dependencies": {
     "@babel/runtime": "^7.26.10",
-    "@bigcommerce/big-design": "^1.4.2",
-    "@bigcommerce/big-design-icons": "^1.1.0",
+    "@bigcommerce/big-design": "^1.7.1",
+    "@bigcommerce/big-design-icons": "^1.2.2",
     "@bigcommerce/big-design-patterns": "^2.0.0",
     "@bigcommerce/big-design-theme": "^1.1.0",
     "dompurify": "^3.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,14 +88,14 @@ importers:
         specifier: ^7.26.10
         version: 7.26.10
       '@bigcommerce/big-design':
-        specifier: ^1.4.2
-        version: 1.6.0(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+        specifier: ^1.7.1
+        version: 1.7.1(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))(use-sync-external-store@1.2.0(react@18.3.1))
       '@bigcommerce/big-design-icons':
-        specifier: ^1.1.0
-        version: 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+        specifier: ^1.2.2
+        version: 1.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       '@bigcommerce/big-design-patterns':
         specifier: ^2.0.0
-        version: 2.0.2(@bigcommerce/big-design-icons@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)))(@bigcommerce/big-design-theme@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)))(@bigcommerce/big-design@1.6.0(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+        version: 2.0.2(@bigcommerce/big-design-icons@1.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)))(@bigcommerce/big-design-theme@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)))(@bigcommerce/big-design@1.7.1(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))(use-sync-external-store@1.2.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       '@bigcommerce/big-design-theme':
         specifier: ^1.1.0
         version: 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
@@ -845,6 +845,13 @@ packages:
       react-dom: ^18.0.0
       styled-components: ^5.3.5
 
+  '@bigcommerce/big-design-icons@1.2.2':
+    resolution: {integrity: sha512-mUEd0Ln9f+2/QdIsE63pxWtpIsBPd6PERWBCJdUHWxFSxdADzKv1qf7QYVZMGqd7PdgDceckxxvyx4dAHavU1w==}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+      styled-components: ^5.3.5
+
   '@bigcommerce/big-design-patterns@2.0.2':
     resolution: {integrity: sha512-dWibBZMvfTXVJ+DBtL+MUgkzLa9lbRsRhIDc+qdtByokzuL/dN4Ra7Y7RFkbnXWkmWnECAkE9GqmleST0WlC/g==}
     peerDependencies:
@@ -864,6 +871,13 @@ packages:
 
   '@bigcommerce/big-design@1.6.0':
     resolution: {integrity: sha512-ssgXJwgI3HkBFRW/r6Baorrbgmmk8ElnUGV+fSEKTbos1YKOfg6MNQchchs0ByE9t2MwhGTl+3UJmoahG83eUw==}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+      styled-components: ^5.3.5
+
+  '@bigcommerce/big-design@1.7.1':
+    resolution: {integrity: sha512-hBUDZeMCxRooT4lAATJCg+cWp9LLiRgG3T7rXodIaL65gtlMTVT5f4+uK/xDjee4L866lLoUpNdRdkUTAYQzDg==}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
@@ -4260,6 +4274,24 @@ packages:
       react:
         optional: true
 
+  zustand@5.0.3:
+    resolution: {integrity: sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   '@ampproject/remapping@2.3.0':
@@ -5164,11 +5196,29 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       styled-components: 5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
 
+  '@bigcommerce/big-design-icons@1.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
+    dependencies:
+      '@babel/runtime': 7.26.10
+      '@bigcommerce/big-design-theme': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      styled-components: 5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+
   '@bigcommerce/big-design-patterns@2.0.2(@bigcommerce/big-design-icons@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)))(@bigcommerce/big-design-theme@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)))(@bigcommerce/big-design@1.6.0(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
     dependencies:
       '@babel/runtime': 7.26.10
       '@bigcommerce/big-design': 1.6.0(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       '@bigcommerce/big-design-icons': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+      '@bigcommerce/big-design-theme': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      styled-components: 5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+
+  '@bigcommerce/big-design-patterns@2.0.2(@bigcommerce/big-design-icons@1.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)))(@bigcommerce/big-design-theme@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)))(@bigcommerce/big-design@1.7.1(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))(use-sync-external-store@1.2.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
+    dependencies:
+      '@babel/runtime': 7.26.10
+      '@bigcommerce/big-design': 1.7.1(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))(use-sync-external-store@1.2.0(react@18.3.1))
+      '@bigcommerce/big-design-icons': 1.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       '@bigcommerce/big-design-theme': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -5204,6 +5254,30 @@ snapshots:
       - '@types/react'
       - immer
       - react-native
+
+  '@bigcommerce/big-design@1.7.1(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))(use-sync-external-store@1.2.0(react@18.3.1))':
+    dependencies:
+      '@babel/runtime': 7.26.10
+      '@bigcommerce/big-design-icons': 1.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+      '@bigcommerce/big-design-theme': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+      '@popperjs/core': 2.11.8
+      '@types/react-datepicker': 7.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      date-fns: 4.1.0
+      downshift: 9.0.8(react@18.3.1)
+      focus-trap: 7.6.2
+      polished: 4.3.1
+      react: 18.3.1
+      react-beautiful-dnd: 13.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-datepicker: 7.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      react-popper: 2.3.0(@popperjs/core@2.11.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      styled-components: 5.3.11(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+      zustand: 5.0.3(@types/react@18.3.3)(react@18.3.1)(use-sync-external-store@1.2.0(react@18.3.1))
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react-native
+      - use-sync-external-store
 
   '@changesets/apply-release-plan@7.0.10':
     dependencies:
@@ -9002,3 +9076,9 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.3
       react: 18.3.1
+
+  zustand@5.0.3(@types/react@18.3.3)(react@18.3.1)(use-sync-external-store@1.2.0(react@18.3.1)):
+    optionalDependencies:
+      '@types/react': 18.3.3
+      react: 18.3.1
+      use-sync-external-store: 1.2.0(react@18.3.1)

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,10 @@
 # BigDesign Patterns Sandbox
 
 This monorepo is a sandbox environment for developing and testing BigDesign Patterns. There are two packages:
-- `examples-site` is a lighweight site that showcases usage of the patterns
+- `examples-site` is a lightweight site that showcases usage of the patterns
 - `patterns` contains the components
 
-The patterns are published on npm under `bigcommerce-design-patterns` so they can be more easily stress tested in apps before being added into the main BigDesign library.
+The patterns are published on npm under [bigcommerce-design-patterns](https://www.npmjs.com/package/bigcommerce-design-patterns) so they can be more easily stress tested in apps before being added into the main BigDesign library.
 
 ## Developing
 
@@ -16,6 +16,8 @@ Before running any commands, make sure you have `pnpm` installed:
 npm install -g pnpm
 ```
 
+### Running the example site
+
 Run the example site in dev mode by:
 ```sh
 pnpm run dev
@@ -23,14 +25,41 @@ pnpm run dev
 
 In dev mode, editing the components within the `patterns` package will hot-reload the example site, as the site uses the workspace to reference the `bigcommerce-design-patterns` dependency.
 
+### Using the local patterns package in another local project
+
+To use the local patterns package in another local project:
+
+1. Add the following to the `package.json` file in your project (updating the path to the local patterns package):
+
+```json
+"bigcommerce-design-patterns": "link:../big-design-patterns-sandbox/packages/patterns",
+```
+
+2. Run `pnpm install` to install the local patterns package, creating a symlink in the local project's `node_modules` directory that points to the local patterns package. Your project will use the built files in the `dist` directory of the patterns package, so you'll need to run `pnpm run build` in the patterns package to build the files before using them in your project. 
+
+#### Hot reloading
+
+If you want to enable hot reloading of the patterns package, you can run `pnpm run build:watch` in the patterns package folder (`big-design-patterns-sandbox/packages/patterns`) to watch for changes and rebuild the files on file save.
+
+## Publishing
+
 ### Using changesets to publish a new version
 
 This repo uses [changesets](https://github.com/changesets/changesets) to version the packages in a consistent manner. It also builds a changelog automatically.
 
-To release a new version after making changes, run:
-`npx @changesets/cli`
+To release a new version with changes:
+
+1. Run the following command to create a new changeset:
+```sh
+npx @changesets/cli
+```
 
 The CLI will ask you to select which package(s) are being updated and if the packages should have a major or minor bump. After confirming these answers, a new changeset will be created in `/.changeset`.
 
-Once that changeset is merged into the main branch, the GitHub Action at `/.github/workflows/release.yml` will run, which creates a version bump PR.
-Merging the version bump PR will release the new package version to NPM.
+2. Commit the generated file in `/.changeset/` to your branch and push to GitHub.
+
+3. Create a PR with your changes and the changeset.
+
+4. Once the PR is approved and merged into the `main` branch, the GitHub Action at `/.github/workflows/release.yml` will run, which creates a version bump PR.
+
+5. Merging the version bump PR will release the new package version to NPM.


### PR DESCRIPTION
The previous updates to the `package.json` allowed one to install `bigcommerce-design-patterns` from NPM and build a project, but didn't allow you to run your project in dev mode with `bigcommerce-design-patterns` installed. 

This PR:

- removes the `development` property from `exports` so that the package works in a dev environment again. It also adds a `default` property for good measure.
- adds a `build:watch` script so that local changes to the components are hotloaded in the `dist` directory.
- bumps the versions of big-design related packages
- expands the readme with info about developing locally and clarifies some steps in the changeset section.