### PR TITLE
Add backgroundSrc property to InstallScreen

### DIFF
--- a/.changeset/dry-birds-travel.md
+++ b/.changeset/dry-birds-travel.md
@@ -1,0 +1,5 @@
+---
+"bigcommerce-design-patterns": patch
+---
+
+Added backgroundSrc property to InstallScreen

--- a/packages/patterns/src/components/InstallScreen/InstallScreen.tsx
+++ b/packages/patterns/src/components/InstallScreen/InstallScreen.tsx
@@ -103,6 +103,7 @@ export interface AppType {
  * Props structure for the InstallScreen component.
  */
 interface InstallScreenProps {
+  backgroundSrc?: string;
   isLoading?: boolean;
   showBackButton?: boolean;
   onBackButtonClick?: () => void;
@@ -206,6 +207,7 @@ const partnerTier = (tier: string, headingText: string): ReactNode => {
  * @returns {JSX.Element} The rendered InstallScreen component.
  */
 export const InstallScreen: FunctionComponent<InstallScreenProps> = ({
+  backgroundSrc,
   isLoading,
   showBackButton = true,
   onBackButtonClick,
@@ -277,12 +279,12 @@ export const InstallScreen: FunctionComponent<InstallScreenProps> = ({
 
   return (
     <Page
-      background={{
-        src: "./assets/images/hero-bg.svg",
+      background={backgroundSrc ? {
+        src: backgroundSrc,
         backgroundPosition: "top right",
         backgroundSize: "100%",
         backgroundRepeat: "no-repeat",
-      }}
+      } : undefined}
     >
       <Grid
         gridColumns={{ mobile: "1fr", desktop: "minmax(0px, 4fr) 425px" }}


### PR DESCRIPTION
Add backgroundSrc property to InstallScreen component because it is currently referencing a specific hardcoded path but it should be made to be generic for the consumer to specify the background image they would like to use.