### PR TITLE
Deploy examples, direct links to pages, fix CardGridItem margin

### DIFF
--- a/.changeset/ninety-stars-wave.md
+++ b/.changeset/ninety-stars-wave.md
@@ -1,0 +1,5 @@
+---
+"bigcommerce-design-patterns": patch
+---
+
+Reduce margins on CardGridItems

--- a/.github/workflows/deploy-examples-site-to-pages.yml
+++ b/.github/workflows/deploy-examples-site-to-pages.yml
@@ -1,53 +1,64 @@
-# Simple workflow for deploying static content to GitHub Pages
 name: Deploy example site's static content to Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
-    branches: ['main']
-
-  # Allows you to run this workflow manually from the Actions tab
+    branches: ["main"]
   workflow_dispatch:
 
-# Sets the GITHUB_TOKEN permissions to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow one concurrent deployment
 concurrency:
-  group: 'pages'
+  group: "pages"
   cancel-in-progress: true
 
 jobs:
-  # Single deploy job since we're just deploying
   deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
+
       - name: Setup PNPM
         uses: pnpm/action-setup@v3
-      - name: Set up Node
+
+      - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
+          cache: "pnpm"
+
       - name: Install dependencies
         run: pnpm install
+
+      - name: Build all packages
+        run: pnpm build
+
       - name: Build examples site
-        run: npm run build-site -- -- --base=/big-design-patterns-sandbox/
-      - name: Setup Pages
+        run: pnpm build-site -- --base=/big-design-patterns-sandbox/
+
+      - name: Verify build output exists
+        run: |
+          if [ ! -d "./packages/examples-site/dist" ]; then
+            echo "❌ Build output not found at ./packages/examples-site/dist"
+            exit 1
+          else
+            echo "✅ Build output found"
+          fi
+
+      - name: Setup GitHub Pages
         uses: actions/configure-pages@v4
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload dist folder for examples-site package
-          path: './packages/examples-site/dist'
+          path: "./packages/examples-site/dist"
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+      - name: Print deployed URL
+        run: echo "🚀 Deployed to ${{ steps.deployment.outputs.page_url }}"

--- a/packages/examples-site/index.html
+++ b/packages/examples-site/index.html
@@ -1,21 +1,43 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="stylesheet" href="/assets/css/styles.css?v=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@200;300;400;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BigDesign Pattern Library</title>
+    <!-- Single page app redirect script -->
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      (function (l) {
+        if (l.search[1] === "/") {
+          var decoded = l.search
+            .slice(1)
+            .split("&")
+            .map(function (s) {
+              return s.replace(/~and~/g, "&");
+            })
+            .join("?");
+          window.history.replaceState(
+            null,
+            null,
+            l.pathname.slice(0, -1) + decoded + l.hash
+          );
+        }
+      })(window.location);
+    </script>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1.0" />
-  <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
-  <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@200;300;400;600;700&amp;display=swap"
-    rel="stylesheet">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>BigDesign Pattern Library</title>
-</head>
-
-<body>
-  <div slot="content" id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div slot="content" id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/packages/examples-site/public/404.html
+++ b/packages/examples-site/public/404.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>BigDesign Patterns</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script takes the current URL and converts the path and query
+      // string into just a query string, and then redirects the browser
+      // to the new URL with only a query string and hash fragment
+
+      var pathSegmentsToKeep = 1; // Adjust based on your repo name
+
+      var l = window.location;
+      l.replace(
+        l.protocol +
+          "//" +
+          l.hostname +
+          (l.port ? ":" + l.port : "") +
+          l.pathname
+            .split("/")
+            .slice(0, 1 + pathSegmentsToKeep)
+            .join("/") +
+          "/?/" +
+          l.pathname
+            .slice(1)
+            .split("/")
+            .slice(pathSegmentsToKeep)
+            .join("/")
+            .replace(/&/g, "~and~") +
+          (l.search ? "&" + l.search.slice(1).replace(/&/g, "~and~") : "") +
+          l.hash
+      );
+    </script>
+  </head>
+  <body>
+    Redirecting...
+  </body>
+</html>

--- a/packages/examples-site/vite.config.ts
+++ b/packages/examples-site/vite.config.ts
@@ -1,7 +1,8 @@
-import { defineConfig } from 'vite'
-import reactRefresh from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import reactRefresh from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [reactRefresh()]
-})
+  plugins: [reactRefresh()],
+  base: "./",
+});

--- a/packages/patterns/src/components/CardGrid/CardGrid.tsx
+++ b/packages/patterns/src/components/CardGrid/CardGrid.tsx
@@ -132,7 +132,7 @@ export const CardGridItem = ({
   ) : (
     description && (
       <Text
-        marginTop="medium"
+        marginTop="xSmall"
         style={{ overflowWrap: "break-word", wordWrap: "break-word" }}
       >
         {description}


### PR DESCRIPTION
This PR:

- Updates the GH action for examples site deployment to build the patterns package first and then build the examples site
- Uses some trickery to simulate a SPA for direct links to pages
- Modifies the margin to on the card grid items to match the Figma design

## Successful deployment of examples site

[bigcommerce/big-design-patterns-sandbox/actions/runs/14389583119/job/40353272899](https://github.com/bigcommerce/big-design-patterns-sandbox/actions/runs/14389583119/job/40353272899)

<img width="387" alt="image" src="https://github.com/user-attachments/assets/7dfe7d2c-e94b-442c-81d5-f69ee8bab957" />

## Direct links to pages:

https://github.com/user-attachments/assets/63b3bdff-cd3b-4f85-b91c-bb07e4e5ab81

