### PR TITLE
Match Dashboard example with Dev Portal usage

### DIFF
--- a/packages/examples-site/src/pages/DashboardLayoutPage/index.tsx
+++ b/packages/examples-site/src/pages/DashboardLayoutPage/index.tsx
@@ -51,7 +51,11 @@ const DashboardLayoutPage: FunctionComponent = () => {
             description:
               "Find answers to your most common development issues with our community of 400+ developers.",
             icon: (
-              <img src="https://storage.googleapis.com/bigcommerce-production-dev-center/images/slack-icon.svg" />
+              <img
+                src="https://storage.googleapis.com/bigcommerce-production-dev-center/images/slack-icon.svg"
+                height="20"
+                width="20"
+              />
             ),
             href: "https://developer.bigcommerce.com/slack",
             hrefTarget: "_blank",
@@ -61,7 +65,11 @@ const DashboardLayoutPage: FunctionComponent = () => {
             description:
               "Gadget provides everything you need to build and run web apps with ease, stitched together from the start.",
             icon: (
-              <img src="https://storage.googleapis.com/bigcommerce-production-dev-center/images/gadget.svg" />
+              <img
+                src="https://storage.googleapis.com/bigcommerce-production-dev-center/images/gadget.svg"
+                height="20"
+                width="20"
+              />
             ),
             href: "https://gadget.dev/use-cases/big-commerce",
             hrefTarget: "_blank",

--- a/packages/examples-site/src/pages/DashboardLayoutPage/index.tsx
+++ b/packages/examples-site/src/pages/DashboardLayoutPage/index.tsx
@@ -26,65 +26,45 @@ const DashboardLayoutPage: FunctionComponent = () => {
     },
   };
 
-  const quickLinksContent = (
-    <AsideCardGrid
-      format="action"
-      items={[
-        {
-          heading: "Quick Links",
-          description: "Access frequently used resources and documentation.",
-          href: "https://developer.bigcommerce.com",
-          hrefTarget: "_blank",
-          icon: (
-            <img
-              src="https://storage.googleapis.com/bigcommerce-developers/images/bigc-dev/bigc-inverted-black.svg"
-              height="45"
-              width="45"
-            />
-          ),
-        },
-        {
-          heading: "Support",
-          description:
-            "Get help with your integration or development questions.",
-          href: "https://support.bigcommerce.com",
-          hrefTarget: "_blank",
-          icon: (
-            <img
-              src="https://storage.googleapis.com/bigcommerce-developers/images/bigc-dev/bigc-inverted-black.svg"
-              height="45"
-              width="45"
-            />
-          ),
-        },
-      ]}
-    />
-  );
-
   const resourcesContent = (
     <AsidePanel title="Resources" padding="medium" headerPadding="medium">
       <AsideCardGrid
         format="action"
         items={[
           {
-            heading: "Documentation",
+            heading: "Developer Docs",
+            headingTag: "h4",
             description:
-              "Access our comprehensive API documentation and guides.",
-            button: {
-              text: "View Docs",
-              onClick: () =>
-                window.open("https://developer.bigcommerce.com", "_blank"),
-            },
+              "Visit our developer hub to browse guides, follow tutorials and find API endpoints.",
+            icon: (
+              <img
+                src="/assets/images/icons/bigc-inverted-black.svg"
+                height="20"
+                width="20"
+              />
+            ),
+            href: "https://developer.bigcommerce.com/docs/build",
+            hrefTarget: "_blank",
           },
           {
-            heading: "Support",
+            heading: "Community Slack",
             description:
-              "Get help with your integration or development questions.",
-            button: {
-              text: "Contact Support",
-              onClick: () =>
-                window.open("https://support.bigcommerce.com", "_blank"),
-            },
+              "Find answers to your most common development issues with our community of 400+ developers.",
+            icon: (
+              <img src="https://storage.googleapis.com/bigcommerce-production-dev-center/images/slack-icon.svg" />
+            ),
+            href: "https://developer.bigcommerce.com/slack",
+            hrefTarget: "_blank",
+          },
+          {
+            heading: "Gadget",
+            description:
+              "Gadget provides everything you need to build and run web apps with ease, stitched together from the start.",
+            icon: (
+              <img src="https://storage.googleapis.com/bigcommerce-production-dev-center/images/gadget.svg" />
+            ),
+            href: "https://gadget.dev/use-cases/big-commerce",
+            hrefTarget: "_blank",
           },
         ]}
       />
@@ -97,7 +77,6 @@ const DashboardLayoutPage: FunctionComponent = () => {
         aside={
           <Flex flexDirection="column" flexGap={theme.spacing.medium}>
             {resourcesContent}
-            {quickLinksContent}
           </Flex>
         }
         header={


### PR DESCRIPTION
This PR updates the Dashboard Layout page to match the new Developer Portal usage by replacing the legacy Quick Links section with updated resource links.

![screencapture-localhost-5173-dashboard-layout-2025-04-25-11_53_53](https://github.com/user-attachments/assets/3412af40-1720-4617-ae1e-b1c58623b2b7)
